### PR TITLE
chore: version 26.0.0 readied

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/zksync-contracts",
-  "version": "1.0.0-beta.4",
+  "version": "26.0.0",
   "description": "ZKsync Smart Contracts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description 

- Updates package.json to reflect protocol-version, 

Once on `main` will cut a release `v26.0.0`. I intend to avoid publishing to npm / soldeer as v26 has already been published. The same flow will apply for v27, and then v28 will go through publishing / release automation.